### PR TITLE
Fix vertical alignment of logo prompt (Issue #3)

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -108,6 +108,7 @@ span[data-note] {
   }
 }
 .logo {
+  position: relative;
   margin: 0 auto 35px;
   text-align: center;
   animation-duration: 0.7s;


### PR DESCRIPTION
The logo prompt (the dialog that appears when hovering over the portrait
at the top of the page) was centered relative to the page, not the logo
(the portrait). Fix this by adding `position: relative` to the logo.

See:
https://css-tricks.com/absolute-positioning-inside-relative-positioning/
