### PR TITLE
Fixed unescaped liquid tag added in error while integrating mathjax

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -40,6 +40,6 @@
 
 {% endif %}
 
-if {% if site.mathjax == true %}
+{% if site.mathjax == true %}
 <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}   


### PR DESCRIPTION
Silly error that crept in has been resolved.