### PR TITLE
Change mathjax cdn, old one shutting down

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -40,5 +40,5 @@
 {% endif %}
 
 {% if site.mathjax == true %}
-<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}


### PR DESCRIPTION
The current cdn for your math formula is gonna shut down, I changed it to the one suggested in the [article](https://www.mathjax.org/cdn-shutting-down/).