### PR TITLE
added https for gravatar images

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,7 +10,7 @@
 
 	{% if site.author_gravatar %}
 		<a href="{{ link | prepend: site.baseurl }}">
-			<img src="http://www.gravatar.com/avatar/{{ site.author_gravatar }}.png?s=80" class="gravatar">
+			<img src="https://www.gravatar.com/avatar/{{ site.author_gravatar }}.png?s=80" class="gravatar">
 		</a>
 		<span class="logo-prompt">{{ prompt }}</span>
 	{% endif %}


### PR DESCRIPTION
removes the mixed content warning on https sites (example at https://i.imgur.com/N0XNR4H.png)