### PR TITLE
update jekyll bundle version

### DIFF
--- a/the-plain.gemspec
+++ b/the-plain.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |spec|
 
 	spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|(LICENSE|README)((\.(txt|md|markdown)|$)))!i) }
 
-	spec.add_runtime_dependency "jekyll", "~> 3.5"
+	spec.add_runtime_dependency "jekyll", "~> 3.8"
 
-	spec.add_development_dependency "bundler", "~> 1.15"
+	spec.add_development_dependency "bundler", "~> 2.0.2"
 	spec.add_development_dependency "rake", "~> 12.0"
 end
 


### PR DESCRIPTION
According from [jekyll docker](https://github.com/envygeeks/jekyll-docker)

jekyll version is up to 3.8
bundle version is up to 2.0.2
